### PR TITLE
[feature] support multiple workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,27 @@ Just install the package globally with this command: `npm i snapshot-creator -g`
 
 ### Creating Snapshots
 - `ss` or `ss build` or `ss create` - Create a snapshot version for the current package
+- `ss --workspace` or `ss -w` - Create a snapshot version that includes the current workspace name as a slug (e.g., `2.1.0-hash-FV-1234-SNAPSHOT`)
 
 ### Workspace Management
-The workspace feature allows you to track published packages across different projects.
+The workspace feature allows you to manage multiple named workspaces to track published packages across different projects and environments.
 
-- `ss workspace add` - Add the current package to your workspace without publishing
-- `ss workspace publish` - Publish the current package to npm and add it to your workspace on successful publish
-- `ss workspace list` - List all packages saved in your workspace  
-- `ss workspace sync` - Update current package.json dependencies to match workspace versions
-- `ss workspace clear` - Clear all packages from your workspace
+#### Basic Workspace Commands
+- `ss workspace add` - Add the current package to your current workspace without publishing
+- `ss workspace publish` - Publish the current package to npm and add it to your current workspace on successful publish
+- `ss workspace list` - List all packages in the current workspace
+- `ss workspace list --name <workspace>` - List all packages in a specific workspace
+- `ss workspace sync` - Update current package.json dependencies to match current workspace versions
+- `ss workspace clear` - Clear all packages from the current workspace
+- `ss workspace clear --name <workspace>` - Clear all packages from a specific workspace
 
-The workspace data is stored in `~/.snapshot-creator-workspace.json` and persists across different projects and terminal sessions. Packages added with `publish` are marked as published, while those added with `add` are marked as unpublished.
+#### Multi-Workspace Management
+- `ss workspace create --name <workspace>` - Create a new workspace
+- `ss workspace use --name <workspace>` - Switch to a different workspace
+- `ss workspace current` - Show the current active workspace
+- `ss workspace ls` - List all available workspaces
+
+The workspace data is stored in `~/.snapshot-creator/` directory with separate files for each workspace and a config file to track the current workspace. This allows you to maintain separate package collections for different projects or tickets (e.g. FV-1234).
 
 ## Usage Examples
 
@@ -26,20 +36,38 @@ The workspace data is stored in `~/.snapshot-creator-workspace.json` and persist
 # Create a snapshot for current package
 ss
 
-# Add current package to workspace without publishing
+# Create a snapshot with workspace name included
+ss --workspace
+# or
+ss -w
+
+# Create and manage workspaces
+ss workspace create --name development
+ss workspace create --name production
+ss workspace ls                    # List all workspaces
+ss workspace current              # Show current workspace
+ss workspace use --name development
+
+# Add current package to current workspace without publishing
 ss workspace add
 
-# Publish current package to npm and add to workspace
+# Publish current package to npm and add to current workspace
 ss workspace publish
 
-# View all packages in workspace
+# View all packages in current workspace
 ss workspace list
 
-# Update current package.json dependencies to workspace versions
+# View packages in a specific workspace
+ss workspace list --name production
+
+# Update current package.json dependencies to current workspace versions
 ss workspace sync
 
-# Clear workspace
+# Clear current workspace
 ss workspace clear
+
+# Clear a specific workspace
+ss workspace clear --name development
 ```
 
 Happy snapshotting!

--- a/bin/index.js
+++ b/bin/index.js
@@ -548,56 +548,70 @@ const addToWorkspace = (argv) => {
 };
 
 const usage = "\nUsage: ss <command> [options]";
-const options = yargs
-    .usage(usage)
-    .command(['build', 'create', '$0'], 'Create and add a new snapshot version to the package.json for the git repo you are currently in!', (yargs) => {
-        return yargs.option('workspace', {
-            alias: 'w',
-            describe: 'Include workspace name in the snapshot version',
-            type: 'boolean',
-            default: false
-        });
-    }, mainFunc)
-    .command(['publish'], 'Publish current package to npm and add to workspace on success', () => {}, publishToWorkspace)
-    .command(['workspace', 'ws'], 'Manage your snapshot workspaces', (yargs) => {
-        return yargs
-            .command('publish', 'Publish current package to npm and add to workspace on success', () => {}, publishToWorkspace)
-            .command('list', 'List all packages in current workspace', (yargs) => {
-                return yargs.option('name', {
-                    alias: 'n',
-                    describe: 'Workspace name to list (defaults to current workspace)',
-                    type: 'string'
-                });
-            }, listWorkspace)
-            .command('clear', 'Clear a workspace', (yargs) => {
-                return yargs.option('name', {
-                    alias: 'n',
-                    describe: 'Workspace name to clear (defaults to current workspace)',
-                    type: 'string'
-                });
-            }, clearWorkspace)
-            .command('sync', 'Sync workspace versions to package.json dependencies', () => {}, syncWorkspace)
-            .command('add', 'Add current package to workspace without publishing', () => {}, addToWorkspace)
-            .command('create', 'Create a new workspace', (yargs) => {
-                return yargs.option('name', {
-                    alias: 'n',
-                    describe: 'Name of the workspace to create',
-                    type: 'string',
-                    demandOption: true
-                });
-            }, createWorkspace)
-            .command('use', 'Switch to a different workspace', (yargs) => {
-                return yargs.option('name', {
-                    alias: 'n',
-                    describe: 'Name of the workspace to switch to',
-                    type: 'string',
-                    demandOption: true
-                });
-            }, switchWorkspace)
-            .command('current', 'Show current workspace', () => {}, getCurrentWorkspace)
-            .command('ls', 'List all available workspaces', () => {}, listWorkspaces)
-            .demandCommand(1, 'You need to specify a workspace command')
-            .help();
-    })
+
+yargs
+.usage(usage)
+.command(['build', 'create', '$0'], 'Create and add a new snapshot version to the package.json for the git repo you are currently in!',
+    (yargs) => yargs.option('workspace', {
+        alias: 'w',
+        describe: 'Include workspace name in the snapshot version',
+        type: 'boolean',
+        default: false
+    }),
+    mainFunc
+)
+.command(['publish'], 'Publish current package to npm and add to workspace on success', () => {}, publishToWorkspace)
+.command(['workspace', 'ws'], 'Manage your snapshot workspaces',
+    (yargs) => yargs
+        .command('publish', 'Publish current package to npm and add to workspace on success', () => {}, publishToWorkspace)
+        .command(
+            'list',
+            'List all packages in current workspace',
+            (yargs) => yargs.option('name', {
+                alias: 'n',
+                describe: 'Workspace name to list (defaults to current workspace)',
+                type: 'string'
+            }),
+            listWorkspace
+        )
+        .command(
+            'clear',
+            'Clear a workspace',
+            (yargs) => yargs.option('name', {
+                alias: 'n',
+                describe: 'Workspace name to clear (defaults to current workspace)',
+                type: 'string'
+            }),
+            clearWorkspace
+        )
+        .command('sync', 'Sync workspace versions to package.json dependencies', () => {}, syncWorkspace)
+        .command('add', 'Add current package to workspace without publishing', () => {}, addToWorkspace)
+        .command(
+            'create',
+            'Create a new workspace',
+            (yargs) => yargs.option('name', {
+                alias: 'n',
+                describe: 'Name of the workspace to create',
+                type: 'string',
+                demandOption: true
+            }),
+            createWorkspace
+        )
+        .command(
+            'use',
+            'Switch to a different workspace',
+            (yargs) => yargs.option('name', {
+                alias: 'n',
+                describe: 'Name of the workspace to switch to',
+                type: 'string',
+                demandOption: true
+            }),
+            switchWorkspace
+        )
+        .command('current', 'Show current workspace', () => {}, getCurrentWorkspace)
+        .command('ls', 'List all available workspaces', () => {}, listWorkspaces)
+        .demandCommand(1, 'You need to specify a workspace command')
+        .help()
+    )
     .help(true)
     .argv;

--- a/bin/index.js
+++ b/bin/index.js
@@ -112,14 +112,14 @@ const publishToWorkspace = (argv) => {
         }
 
     } catch(e) {
-      if (e.stdout) {
-        console.log('npm output:', e.stdout);
-      }
-      if (e.stderr) {
-        console.log('npm error:', e.stderr);
-      }
-      utils.errorLog(e, 'Package was not added to workspace due to publish failure');
-      console.log('❌ Failed to publish package');
+        if (e.stdout) {
+            console.log('npm output:', e.stdout);
+        }
+        if (e.stderr) {
+            console.log('npm error:', e.stderr);
+        }
+        utils.errorLog(e, 'Package was not added to workspace due to publish failure');
+        console.log('❌ Failed to publish package');
     }
 }
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -222,7 +222,7 @@ const syncWorkspace = (argv) => {
     let packageJson = null;
     let originalJsonStr = '';
     try {
-        originalJsonStr = fs.readFileSync(`${runtimeDirectory}/package.json`);
+        originalJsonStr = fs.readFileSync(`${runtimeDirectory}/package.json`, 'utf8');
         packageJson = JSON.parse(originalJsonStr);
     } catch(e) {
         utils.errorLog(e, 'Oops! Can\'t seem to find your package.json in current directory.');

--- a/bin/utils.js
+++ b/bin/utils.js
@@ -4,4 +4,18 @@ const errorLog = (e, customLog) => {
     console.log(customLog);
 }
 
-module.exports = { errorLog };
+const getJsonStrWithUpdatedDependency = (jsonStr, packageName, newVersion) => {
+    const dependencyRegex = new RegExp(`("${packageName}"\\s*:\\s*")[^"]*(")`);
+    return jsonStr.replace(dependencyRegex, `$1${newVersion}$2`);
+};
+
+const getJsonStrWithUpdatedVersion = (jsonStr, newVersion) => {
+    const versionRegex = /("version"\s*:\s*")[^"]*(")/;
+    return jsonStr.replace(versionRegex, `$1${newVersion}$2`);
+};
+
+module.exports = {
+    errorLog,
+    getJsonStrWithUpdatedDependency,
+    getJsonStrWithUpdatedVersion
+};

--- a/bin/utils.js
+++ b/bin/utils.js
@@ -4,9 +4,10 @@ const errorLog = (e, customLog) => {
     console.log(customLog);
 }
 
-const getJsonStrWithUpdatedDependency = (jsonStr, packageName, newVersion) => {
-    const dependencyRegex = new RegExp(`("${packageName}"\\s*:\\s*")[^"]*(")`);
-    return jsonStr.replace(dependencyRegex, `$1${newVersion}$2`);
+const getJsonStrWithUpdatedDependency = (jsonStr, packageName, newVersion, section = 'dependencies') => {
+    // matches the dependency within the specific section
+    const sectionRegex = new RegExp(`("${section}"\\s*:\\s*{[^}]*?"${packageName}"\\s*:\\s*")[^"]*(")`);
+    return jsonStr.replace(sectionRegex, `$1${newVersion}$2`);
 };
 
 const getJsonStrWithUpdatedVersion = (jsonStr, newVersion) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "snapshot-creator",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "snapshot-creator",
-      "version": "2.0.0-beta.1",
+      "version": "2.0.0-beta.2",
       "license": "ISC",
       "dependencies": {
-        "json-beautify": "^1.1.1",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -94,14 +93,6 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/json-beautify": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/json-beautify/-/json-beautify-1.1.1.tgz",
-      "integrity": "sha512-17j+Hk2lado0xqKtUcyAjK0AtoHnPSIgktWRsEXgdFQFG9UnaGw6CHa0J7xsvulxRpFl6CrkDFHght1p5ZJc4A==",
-      "bin": {
-        "json-beautify": "bin/json-beautify"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snapshot-creator",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "A CLI to create snapshots for testing packages based on your most recent git hash",
   "main": "./bin/index.js",
   "scripts": {
@@ -16,7 +16,6 @@
   "author": "Zach Shuffield",
   "license": "ISC",
   "dependencies": {
-    "json-beautify": "^1.1.1",
     "yargs": "^17.7.2"
   }
 }


### PR DESCRIPTION
- **NEW: Multiple Workspace Support** - Added support for multiple named workspaces
- **NEW: Workspace Management Commands**:
  - `ss workspace create --name <workspace>` - Create a new workspace
  - `ss workspace use --name <workspace>` - Switch to a different workspace
  - `ss workspace current` - Show current active workspace
  - `ss workspace ls` - List all available workspaces
  - `ss workspace list --name <workspace>` - View packages in a specific workspace
  - `ss workspace clear --name <workspace>` - Clear a specific workspace
- **BREAKING: Workspace Storage Format** - Workspaces are now stored in `~/.snapshot-creator/` directory instead of a single file
- **ENHANCEMENT**: Improved workspace isolation - each workspace maintains its own package collection
- **ENHANCEMENT**: Auto-switching to remaining workspace when current workspace is cleared